### PR TITLE
Fix WriterOnce default value for MemBytes option

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -68,13 +68,13 @@ func NewWriterOnce(setters ...optionSetter) (WriterOnce, error) {
 		memBytes: DefaultMemBytes,
 		maxBytes: DefaultMaxBytes,
 	}
-	if o.memBytes == 0 {
-		o.memBytes = DefaultMemBytes
-	}
 	for _, s := range setters {
 		if err := s(&o); err != nil {
 			return nil, err
 		}
+	}
+	if o.memBytes == 0 {
+		o.memBytes = DefaultMemBytes
 	}
 	return &writerOnce{o: o}, nil
 }

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -164,6 +164,16 @@ func TestWriteToSmallBuffer(t *testing.T) {
 	assert.Equal(t, hash, hashOfReader(other))
 }
 
+func TestWriterOnceMemBytesDefault(t *testing.T) {
+	w, err := NewWriterOnce(MemBytes(0))
+	assert.NoError(t, err)
+
+	wo, ok := w.(*writerOnce)
+	assert.True(t, ok)
+
+	assert.Equal(t, DefaultMemBytes, int(wo.o.memBytes))
+}
+
 func TestWriterOnceSmallBuffer(t *testing.T) {
 	r, hash := createReaderOfSize(1)
 


### PR DESCRIPTION
## Motivation

This pull request fixes the default value of the `MemBytes` option when creating a `WriterOnce` instance.


## Additional Notes

Co-authored-by: Mathieu Lonjaret <mathieu.lonjaret@gmail.com> 